### PR TITLE
Adds support for request timeout

### DIFF
--- a/deps/coro-http.lua
+++ b/deps/coro-http.lua
@@ -75,7 +75,7 @@ local function getConnection(host, port, tls, timeout)
     host = host,
     port = port,
     tls = tls,
-	timeout = timeout,
+    timeout = timeout,
     encode = httpCodec.encoder(),
     decode = httpCodec.decoder()
   })

--- a/deps/coro-http.lua
+++ b/deps/coro-http.lua
@@ -58,7 +58,7 @@ end
 
 local connections = {}
 
-local function getConnection(host, port, tls)
+local function getConnection(host, port, tls, timeout)
   for i = #connections, 1, -1 do
     local connection = connections[i]
     if connection.host == host and connection.port == port and connection.tls == tls then
@@ -75,6 +75,7 @@ local function getConnection(host, port, tls)
     host = host,
     port = port,
     tls = tls,
+	timeout = timeout,
     encode = httpCodec.encoder(),
     decode = httpCodec.decoder()
   })
@@ -101,9 +102,9 @@ local function saveConnection(connection)
   connection.socket:unref()
 end
 
-local function request(method, url, headers, body)
+local function request(method, url, headers, body, timeout)
   local uri = parseUrl(url)
-  local connection = getConnection(uri.hostname, uri.port, uri.tls)
+  local connection = getConnection(uri.hostname, uri.port, uri.tls, timeout)
   local read = connection.read
   local write = connection.write
 


### PR DESCRIPTION
Re: #216

`coro-net.connect` supports timeouts, so this is just a matter of passing the argument along from `coro-http.request`. There's no request handle like there is with luvit, so I guess this is the best way to do it.